### PR TITLE
Pom naming changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.kinde.sdk</groupId>
-    <artifactId>kinde</artifactId>
+    <groupId>com.kinde</groupId>
+    <artifactId>java-sdk</artifactId>
     <packaging>jar</packaging>
-    <name>kinde</name>
-    <version>1</version>
+    <name>java-sdk</name>
+    <version>1.0.0</version>
     <url>https://github.com/kinde-oss/kinde-java-sdk/</url>
     <description>Kinde Java SDK</description>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.openapitools</groupId>
-    <artifactId>openapi-spring</artifactId>
+    <groupId>com.kinde.sdk</groupId>
+    <artifactId>kinde</artifactId>
     <packaging>jar</packaging>
-    <name>openapi-spring</name>
+    <name>kinde</name>
     <version>1</version>
+    <url>https://github.com/kinde-oss/kinde-java-sdk/</url>
+    <description>Kinde Java SDK</description>
     <properties>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -22,6 +24,38 @@
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
         <plugins>
+            <!-- We must generate a -javadoc JAR file to publish on Maven Central. Since docs are manual, creating empty package -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>empty-javadoc-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>javadoc</classifier>
+                            <classesDirectory>${basedir}/javadoc</classesDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+                        <!-- We must generate a -sources JAR file to publish on Maven Central -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -43,7 +77,6 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <finalName>kindejava</finalName>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
# Explain your changes
Adjusted POM to be able to upload to Maven. 
Currently setup as: 
```
<dependency>
  <groupId>com.kinde.sdk</groupId>
  <artifactId>kinde</artifactId>
  <version>1</version>
</dependency>
```
We can change the artifactid, but followed the guidelines. I see that the other android one is following a different naming structure but don't think it matters that much. 

```
<dependency>
  <groupId>com.kinde</groupId>
  <artifactId>android-sdk</artifactId>
  <version>1.2.1</version>
  <type>module</type>
</dependency>
```

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
