### PR TITLE
Set tokenTimeToLive in seconds from now

### DIFF
--- a/src/main/java/org/openapitools/sdk/storage/Storage.java
+++ b/src/main/java/org/openapitools/sdk/storage/Storage.java
@@ -87,7 +87,7 @@ public class Storage extends BaseStorage {
     }
 
     public static Long getTokenTimeToLive() {
-        return tokenTimeToLive != null ? tokenTimeToLive : System.currentTimeMillis() + 3600 * 24 * 15 * 1000; // Live in 15 days
+        return tokenTimeToLive != null ? tokenTimeToLive : 3600 * 24 * 15; // Live in 15 days
     }
 
     public static void setTokenTimeToLive(Long tokenTTL) {

--- a/src/main/java/org/openapitools/sdk/storage/Storage.java
+++ b/src/main/java/org/openapitools/sdk/storage/Storage.java
@@ -99,7 +99,7 @@ public class Storage extends BaseStorage {
     }
 
     public static void setState( HttpServletResponse response,String newState) {
-        setItem(response,StorageEnums.STATE.getValue(), newState,(int) ((long) (System.currentTimeMillis() + 3600 *2 )));
+        setItem(response,StorageEnums.STATE.getValue(), newState, 3600 * 2); // 2 hours
         // set expiration time for state
     }
 
@@ -108,7 +108,7 @@ public class Storage extends BaseStorage {
     }
 
     public static void setCodeVerifier(HttpServletResponse response,String newCodeVerifier) {
-        setItem(response,StorageEnums.CODE_VERIFIER.getValue(), newCodeVerifier,(int) ((long) (System.currentTimeMillis() + 3600 *2 )));
+        setItem(response,StorageEnums.CODE_VERIFIER.getValue(), newCodeVerifier, 3600 * 2); // 2 hours
         // set expiration time for code verifier
     }
 


### PR DESCRIPTION
`getTokenTimeToLive` uses a default value 15 days from current date in milliseconds:

```
System.currentTimeMillis() + 3600 * 24 * 15 * 1000
```

However, the value is then used to configure the [Max-Age cookie property](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#max-agenumber]): https://github.com/kinde-oss/kinde-java-sdk/blob/main/src/main/java/org/openapitools/sdk/storage/Storage.java#L65

According to MDN web docs, the max-age of a cookie "_Indicates the number of seconds until the cookie expires_", so it should be specified in seconds from now.

For this reason, I'm changing the default value used here to reflect 15 days in seconds

# Explain your changes

_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
