### PR TITLE
Max-Age-Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules/
 # Compiled output
 dist/
 build/
+target/
 coverage/
 
 # Generated at runtime

--- a/src/main/java/org/openapitools/sdk/CallbackController.java
+++ b/src/main/java/org/openapitools/sdk/CallbackController.java
@@ -90,12 +90,8 @@ public class CallbackController {
 
                     String newKey = "kinde" + '_' + StorageEnums.TOKEN.getValue();
                     Cookie cookie = new Cookie(newKey, URLEncoder.encode(new ObjectMapper().writeValueAsString((Map<String, Object>) data_), "UTF-8"));
-                    Long exp = System.currentTimeMillis() + 3600 * 24 * 15 * 1000;
-                    cookie.setMaxAge(exp.intValue());
-//                    long currentTimeSeconds = System.currentTimeMillis() / 1000;
-//                    cookie.setMaxAge((int) ((long) (Integer) payload.get("exp")- currentTimeSeconds));
+                    cookie.setMaxAge(Storage.MAX_AGE_15_DAYS);
                     cookie.setPath("/");
-//                cookie.setDomain(domain);
                     cookie.setSecure(true);
                     cookie.setHttpOnly(true);
                     response.addCookie(cookie);

--- a/src/main/java/org/openapitools/sdk/storage/Storage.java
+++ b/src/main/java/org/openapitools/sdk/storage/Storage.java
@@ -14,10 +14,10 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class Storage extends BaseStorage {
 
-
+    private static final int MAX_AGE_15_DAYS = 3600 * 24 * 15;
+    private static final int MAX_AGE_2_HOURS = 3600 * 2;
 
     private static Storage instance;
-    private static Long tokenTimeToLive;
 
     private static final Map<String, String> storageMap = new ConcurrentHashMap<>();
 
@@ -62,7 +62,7 @@ public class Storage extends BaseStorage {
             }
         }
 
-        setItem(response,StorageEnums.TOKEN.getValue(), tok, getTokenTimeToLive().intValue());
+        setItem(response,StorageEnums.TOKEN.getValue(), tok, MAX_AGE_15_DAYS);
     }
 
     public static String getAccessToken(HttpServletRequest request) {
@@ -86,20 +86,12 @@ public class Storage extends BaseStorage {
         return accessToken != null ? ((Integer) Utils.parseJWT(accessToken).get("exp")).longValue() : 0L;
     }
 
-    public static Long getTokenTimeToLive() {
-        return tokenTimeToLive != null ? tokenTimeToLive : System.currentTimeMillis() + 3600 * 24 * 15 * 1000; // Live in 15 days
-    }
-
-    public static void setTokenTimeToLive(Long tokenTTL) {
-        tokenTimeToLive = tokenTTL;
-    }
-//
     public static String getState(HttpServletRequest request) {
         return getItem(request,StorageEnums.STATE.getValue());
     }
 
     public static void setState( HttpServletResponse response,String newState) {
-        setItem(response,StorageEnums.STATE.getValue(), newState,(int) ((long) (System.currentTimeMillis() + 3600 *2 )));
+        setItem(response,StorageEnums.STATE.getValue(), newState,MAX_AGE_2_HOURS );
         // set expiration time for state
     }
 
@@ -108,7 +100,7 @@ public class Storage extends BaseStorage {
     }
 
     public static void setCodeVerifier(HttpServletResponse response,String newCodeVerifier) {
-        setItem(response,StorageEnums.CODE_VERIFIER.getValue(), newCodeVerifier,(int) ((long) (System.currentTimeMillis() + 3600 *2 )));
+        setItem(response,StorageEnums.CODE_VERIFIER.getValue(), newCodeVerifier,MAX_AGE_2_HOURS);
         // set expiration time for code verifier
     }
 

--- a/src/main/java/org/openapitools/sdk/storage/Storage.java
+++ b/src/main/java/org/openapitools/sdk/storage/Storage.java
@@ -14,8 +14,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class Storage extends BaseStorage {
 
-    private static final int MAX_AGE_15_DAYS = 3600 * 24 * 15;
-    private static final int MAX_AGE_2_HOURS = 3600 * 2;
+    public static final int MAX_AGE_15_DAYS = 3600 * 24 * 15;
+    public static final int MAX_AGE_2_HOURS = 3600 * 2;
 
     private static Storage instance;
 


### PR DESCRIPTION
Fixed .gitignore to ignore the target folder
Converted Long's to Integers to prevent long to int conversion issues. Added 2 constants MAX_AGE_15_DAYS and MAX_AGE_2_HOURS Removed tokenTimeToLive variable and methods as the constants now replace them.

# Explain your changes

This is a fix of the max age issue https://github.com/kinde-oss/kinde-java-sdk/issues/12
Due to the fact that the expiry time was defined original in a Long and not an Integer. And the Long was simply cast to an integer, resulting in a conversation issue and according to the bug, and expired token.
I have removed the original expiry member variable in favour of a constant. There are now two constants one for the 15 day max period and one for 2 hours. The are used instead of the calculations that were in place.

I have have tested this using the Java starter project and compared it to the NextJS project. It appears to work correctly.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
