### PR TITLE
Add Codecov reporting

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,9 +16,8 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 17
@@ -29,5 +28,14 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml
-    - name: Run tests
-      run: mvn test
+
+    - name: Run tests and collect coverage
+      working-directory: ./kinde-core
+      run: mvn jacoco:report
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        files: '**/target/site/jacoco/jacoco.xml'
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,6 @@
           </execution>
         </executions>
       </plugin>
-
     </plugins>
   </build>
 


### PR DESCRIPTION
# Explain your changes

This pull request adds Codecov reporting to the project. It includes a new step in the CI pipeline that runs the tests and collects coverage data using Maven. The coverage data is then uploaded to Codecov using the Codecov Action.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._

This pull request adds Codecov reporting to the project. It includes a new step in the CI pipeline that runs the tests and collects coverage data using Maven. The coverage data is then uploaded to Codecov using the Codecov Action.