### PR TITLE
Fix login dependency issue with spring boot thymeleaf playground example

### DIFF
--- a/kinde-core/src/main/java/com/kinde/config/KindeConfig.java
+++ b/kinde-core/src/main/java/com/kinde/config/KindeConfig.java
@@ -1,10 +1,7 @@
 package com.kinde.config;
 
-import com.kinde.KindeClientBuilder;
 import com.kinde.authorization.AuthorizationType;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 

--- a/playground/kinde-springboot-thymeleaf-full-example/.env
+++ b/playground/kinde-springboot-thymeleaf-full-example/.env
@@ -10,3 +10,4 @@ KINDE_CLIENT_SECRET=< replace >
 KINDE_GRANT_TYPE=authorization_code
 KINDE_SCOPES=openid,profile,email,offline
 KINDE_PREFIX=< replace >
+KINDE_LOGOUT_REDIRECT_URI=http://localhost:8081

--- a/playground/kinde-springboot-thymeleaf-full-example/.env
+++ b/playground/kinde-springboot-thymeleaf-full-example/.env
@@ -1,6 +1,12 @@
+KINDE_REDIRECT_URI=http://localhost:8081/login/oauth2/code/kinde
 KINDE_DOMAIN=https://< replace >.kinde.com
+KINDE_ISSUER_URI=https://< replace >.kinde.com
+KINDE_AUTHORIZATION_URI=https://< replace >.kinde.com/oauth2/auth
+KINDE_TOKEN_URI=https://< replace >.kinde.com/oauth2/token
+KINDE_USER_INFO_URI=https://< replace >.kinde.com/oauth2/v2/user_profile
+KINDE_JWKS_URI=https://< replace >.kinde.com/.well-known/jwks
 KINDE_CLIENT_ID=< replace >
 KINDE_CLIENT_SECRET=< replace >
-KINDE_REDIRECT_URI=http://localhost:8081/login/oauth2/code/kinde-provider
 KINDE_GRANT_TYPE=authorization_code
-KINDE_SCOPES=openid,profile,email
+KINDE_SCOPES=openid,profile,email,offline
+KINDE_PREFIX=< replace >

--- a/playground/kinde-springboot-thymeleaf-full-example/pom.xml
+++ b/playground/kinde-springboot-thymeleaf-full-example/pom.xml
@@ -85,12 +85,6 @@
             <scope>test</scope>
             <version>3.5.5</version>
         </dependency>
-
-        <dependency>
-            <groupId>com.kinde.spring</groupId>
-            <artifactId>kinde-springboot-starter</artifactId>
-            <version>2.1.0</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/playground/kinde-springboot-thymeleaf-full-example/src/main/java/com/kinde/oauth/controller/KindeController.java
+++ b/playground/kinde-springboot-thymeleaf-full-example/src/main/java/com/kinde/oauth/controller/KindeController.java
@@ -83,6 +83,17 @@ public class KindeController {
     }
 
     /**
+     * Handles requests to the read endpoint, restricted to users with the 'read' role.
+     *
+     * @return the name of the "read" view.
+     */
+    @GetMapping("/edit")
+    @PreAuthorize("hasRole('edit')")
+    public String editEndpoint() {
+        return "edit";
+    }
+
+    /**
      * Handles requests to the write endpoint, restricted to users with the 'write' role.
      * See SecurityConfig for 'write' role definition.
      *

--- a/playground/kinde-springboot-thymeleaf-full-example/src/main/resources/templates/dashboard.html
+++ b/playground/kinde-springboot-thymeleaf-full-example/src/main/resources/templates/dashboard.html
@@ -66,7 +66,7 @@
                             </a>
                         </li>
                         <li>
-                            <a class="btn btn-light btn-small fixed-size-button" href="/generatePortalUrl">
+                            <a target="_blank" class="btn btn-light btn-small fixed-size-button" href="/generatePortalUrl">
                                 Account Portal
                             </a>
                         </li>

--- a/playground/kinde-springboot-thymeleaf-full-example/src/main/resources/templates/edit.html
+++ b/playground/kinde-springboot-thymeleaf-full-example/src/main/resources/templates/edit.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <title>KindeAuth</title>
+    <link rel="stylesheet" type="text/css" th:href="@{/css/index.css}"/>
+
+</head>
+<body>
+<header>
+    <nav class="nav container">
+        <h1 class="text-display-3">KindeAuth with Spring Boot</h1>
+    </nav>
+</header>
+
+<main>
+    <div class="container">
+        <div class="card hero">
+            <p class="text-display-1 hero-title">
+                Yes! You can edit things here.
+            </p>
+
+            <a href="/dashboard" rel="noreferrer" class="btn btn-light btn-big">
+                Home
+            </a>
+        </div>
+    </div>
+</main>
+
+<footer class="footer">
+    <div class="container">
+        <p class="footer-tagline text-body-3">
+            Browse Kinde
+            <a class="link" target="_blank" href="https://kinde.com/docs">docs</a>
+        </p>
+
+        <small class="text-subtle">© 2024 KindeAuth, Inc. All rights reserved</small>
+    </div>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
# Playground example app login fix

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an /edit page guarded for users with the "edit" role.

* **Chores**
  * Removed a bundled authentication library from the Spring Boot + Thymeleaf example; example no longer includes that auth starter.
  * No new dependencies added; other dependencies unchanged.

* **Refactor**
  * Cleaned up unused imports to streamline code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->