### PR TITLE
feat: Add Connection ID support across all frameworks

### DIFF
--- a/kinde-core/src/main/java/com/kinde/constants/KindeConstants.java
+++ b/kinde-core/src/main/java/com/kinde/constants/KindeConstants.java
@@ -7,5 +7,6 @@ public class KindeConstants {
     public final static String ORG_CODE = "org_code";
     public final static String LANG = "lang";
     public final static String ORG_NAME = "org_name";
+    public final static String CONNECTION_ID = "connection_id";
     public final static String SCOPE = "openid,email,profile";
 }

--- a/kinde-core/src/main/java/com/kinde/session/KindeRequestParameters.java
+++ b/kinde-core/src/main/java/com/kinde/session/KindeRequestParameters.java
@@ -5,4 +5,5 @@ public class KindeRequestParameters {
     public final static String HAS_SUCCESS_PAGE = "has_success_page";
     public final static String LANG = "lang";
     public final static String ORG_CODE = "org_code";
+    public final static String CONNECTION_ID = "connection_id";
 }

--- a/kinde-core/src/main/java/com/kinde/token/BaseToken.java
+++ b/kinde-core/src/main/java/com/kinde/token/BaseToken.java
@@ -1,6 +1,5 @@
 package com.kinde.token;
 
-import com.google.inject.Inject;
 import com.kinde.accounts.KindeAccountsClient;
 import com.kinde.accounts.dto.PermissionDto;
 import com.kinde.accounts.dto.RoleDto;
@@ -89,6 +88,33 @@ public class BaseToken implements KindeToken {
             return null; // Return null for invalid tokens instead of throwing NPE
         }
         return this.signedJWT.getJWTClaimsSet().getClaim(key);
+    }
+
+    @Override
+    @SneakyThrows
+    public String getConnectionId() {
+        if (this.signedJWT == null) {
+            return null;
+        }
+        
+        // First, try direct connection_id claim
+        Object connectionId = getClaim("connection_id");
+        if (connectionId instanceof String) {
+            return (String) connectionId;
+        }
+        
+        // Then, try nested ext_provider.connection_id structure
+        Object extProvider = getClaim("ext_provider");
+        if (extProvider instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> extProviderMap = (Map<String, Object>) extProvider;
+            Object nestedConnectionId = extProviderMap.get("connection_id");
+            if (nestedConnectionId instanceof String) {
+                return (String) nestedConnectionId;
+            }
+        }
+        
+        return null;
     }
 
     @SuppressWarnings("unchecked")

--- a/kinde-core/src/main/java/com/kinde/token/KindeToken.java
+++ b/kinde-core/src/main/java/com/kinde/token/KindeToken.java
@@ -17,6 +17,17 @@ public interface KindeToken {
 
     Object getClaim(String key);
 
+    /**
+     * Gets the connection ID from the token.
+     * This method checks for connection_id in the token claims, including nested structures
+     * like ext_provider.connection_id for external identity providers.
+     * 
+     * @return The connection ID string, or null if not found
+     */
+    default String getConnectionId() {
+        return null;
+    }
+
     List<String> getPermissions();
 
     /**

--- a/kinde-core/src/test/java/com/kinde/session/ConnectionIdTest.java
+++ b/kinde-core/src/test/java/com/kinde/session/ConnectionIdTest.java
@@ -1,0 +1,167 @@
+package com.kinde.session;
+
+import com.kinde.KindeClient;
+import com.kinde.KindeClientBuilder;
+import com.kinde.KindeClientSession;
+import com.kinde.authorization.AuthorizationType;
+import com.kinde.authorization.AuthorizationUrl;
+import com.kinde.client.KindeCoreGuiceTestModule;
+import com.kinde.guice.KindeEnvironmentSingleton;
+import com.kinde.guice.KindeGuiceSingleton;
+import com.kinde.token.KindeTokenGuiceTestModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConnectionIdTest {
+
+    @BeforeEach
+    public void setUp() {
+        KindeGuiceSingleton.fin();
+        KindeEnvironmentSingleton.fin();
+        KindeEnvironmentSingleton.init(KindeEnvironmentSingleton.State.ACTIVE);
+        
+        KindeGuiceSingleton.init(
+                new KindeCoreGuiceTestModule(),
+                new KindeTokenGuiceTestModule());
+    }
+
+    @Test
+    @DisplayName("authorizationUrlWithParameters should include connection_id when provided")
+    public void testAuthorizationUrlWithConnectionId() {
+        KindeClient kindeClient = KindeClientBuilder.builder()
+                .domain("http://localhost:8089")
+                .clientId("test")
+                .clientSecret("test")
+                .redirectUri("http://localhost:8080/")
+                .build();
+        
+        KindeClientSession kindeClientSession = kindeClient.initClientSession("test", null);
+        
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(KindeRequestParameters.CONNECTION_ID, "conn_123456789");
+        
+        AuthorizationUrl authorizationUrl = kindeClientSession.authorizationUrlWithParameters(parameters);
+        
+        assertNotNull(authorizationUrl);
+        assertNotNull(authorizationUrl.getUrl());
+        String urlString = authorizationUrl.getUrl().toString();
+        assertTrue(urlString.contains("connection_id=conn_123456789"), 
+                "URL should contain connection_id parameter. URL: " + urlString);
+    }
+
+    @Test
+    @DisplayName("login should support connection_id via authorizationUrlWithParameters")
+    public void testLoginWithConnectionId() {
+        KindeClient kindeClient = KindeClientBuilder.builder()
+                .domain("http://localhost:8089")
+                .clientId("test")
+                .clientSecret("test")
+                .redirectUri("http://localhost:8080/")
+                .build();
+        
+        KindeClientSession kindeClientSession = kindeClient.initClientSession("test", null);
+        
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("supports_reauth", "true");
+        parameters.put(KindeRequestParameters.CONNECTION_ID, "conn_social_google");
+        
+        AuthorizationUrl authorizationUrl = kindeClientSession.authorizationUrlWithParameters(parameters);
+        
+        assertNotNull(authorizationUrl);
+        assertNotNull(authorizationUrl.getUrl());
+        String urlString = authorizationUrl.getUrl().toString();
+        assertTrue(urlString.contains("connection_id=conn_social_google"), 
+                "URL should contain connection_id parameter. URL: " + urlString);
+        assertTrue(urlString.contains("supports_reauth=true"), 
+                "URL should contain supports_reauth parameter. URL: " + urlString);
+    }
+
+    @Test
+    @DisplayName("register should support connection_id via authorizationUrlWithParameters")
+    public void testRegisterWithConnectionId() {
+        KindeClient kindeClient = KindeClientBuilder.builder()
+                .domain("http://localhost:8089")
+                .clientId("test")
+                .clientSecret("test")
+                .redirectUri("http://localhost:8080/")
+                .build();
+        
+        KindeClientSession kindeClientSession = kindeClient.initClientSession("test", null);
+        
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("prompt", "create");
+        parameters.put(KindeRequestParameters.CONNECTION_ID, "conn_enterprise_saml");
+        
+        AuthorizationUrl authorizationUrl = kindeClientSession.authorizationUrlWithParameters(parameters);
+        
+        assertNotNull(authorizationUrl);
+        assertNotNull(authorizationUrl.getUrl());
+        String urlString = authorizationUrl.getUrl().toString();
+        assertTrue(urlString.contains("connection_id=conn_enterprise_saml"), 
+                "URL should contain connection_id parameter. URL: " + urlString);
+        assertTrue(urlString.contains("prompt=create"), 
+                "URL should contain prompt parameter. URL: " + urlString);
+    }
+
+    @Test
+    @DisplayName("connection_id should work with CODE grant type")
+    public void testConnectionIdWithCodeGrant() {
+        KindeClient kindeClient = KindeClientBuilder.builder()
+                .domain("http://localhost:8089")
+                .clientId("test")
+                .clientSecret("test")
+                .redirectUri("http://localhost:8080/")
+                .grantType(AuthorizationType.CODE)
+                .build();
+        
+        KindeClientSession kindeClientSession = kindeClient.initClientSession("test", null);
+        
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(KindeRequestParameters.CONNECTION_ID, "conn_123456789");
+        
+        AuthorizationUrl authorizationUrl = kindeClientSession.authorizationUrlWithParameters(parameters);
+        
+        assertNotNull(authorizationUrl);
+        assertNotNull(authorizationUrl.getUrl());
+        assertNotNull(authorizationUrl.getCodeVerifier(), "Code verifier should be present for CODE grant type");
+        String urlString = authorizationUrl.getUrl().toString();
+        assertTrue(urlString.contains("connection_id=conn_123456789"), 
+                "URL should contain connection_id parameter. URL: " + urlString);
+    }
+
+    @Test
+    @DisplayName("connection_id should work with other parameters like org_code and lang")
+    public void testConnectionIdWithOtherParameters() {
+        KindeClient kindeClient = KindeClientBuilder.builder()
+                .domain("http://localhost:8089")
+                .clientId("test")
+                .clientSecret("test")
+                .redirectUri("http://localhost:8080/")
+                .orgCode("ORG123")
+                .lang("en")
+                .build();
+        
+        KindeClientSession kindeClientSession = kindeClient.initClientSession("test", null);
+        
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(KindeRequestParameters.CONNECTION_ID, "conn_123456789");
+        
+        AuthorizationUrl authorizationUrl = kindeClientSession.authorizationUrlWithParameters(parameters);
+        
+        assertNotNull(authorizationUrl);
+        assertNotNull(authorizationUrl.getUrl());
+        String urlString = authorizationUrl.getUrl().toString();
+        assertTrue(urlString.contains("connection_id=conn_123456789"), 
+                "URL should contain connection_id parameter. URL: " + urlString);
+        assertTrue(urlString.contains("org_code=ORG123"), 
+                "URL should contain org_code parameter. URL: " + urlString);
+        assertTrue(urlString.contains("lang=en"), 
+                "URL should contain lang parameter. URL: " + urlString);
+    }
+}

--- a/kinde-core/src/test/java/com/kinde/session/ConnectionIdTest.java
+++ b/kinde-core/src/test/java/com/kinde/session/ConnectionIdTest.java
@@ -24,7 +24,7 @@ public class ConnectionIdTest {
     public void setUp() {
         KindeGuiceSingleton.fin();
         KindeEnvironmentSingleton.fin();
-        KindeEnvironmentSingleton.init(KindeEnvironmentSingleton.State.ACTIVE);
+        KindeEnvironmentSingleton.init(KindeEnvironmentSingleton.State.TEST);
         
         KindeGuiceSingleton.init(
                 new KindeCoreGuiceTestModule(),

--- a/kinde-core/src/test/java/com/kinde/token/ConnectionIdTokenTest.java
+++ b/kinde-core/src/test/java/com/kinde/token/ConnectionIdTokenTest.java
@@ -1,0 +1,125 @@
+package com.kinde.token;
+
+import com.kinde.token.jwt.JwtGenerator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConnectionIdTokenTest {
+
+    @Test
+    @DisplayName("getConnectionId should return connection_id from token when present as direct claim")
+    public void testGetConnectionIdDirectClaim() throws Exception {
+        String connectionId = "conn_123456789";
+        String tokenString = JwtGenerator.generateIDTokenWithConnectionId(connectionId);
+        
+        KindeToken kindeToken = IDToken.init(tokenString, true);
+        
+        assertNotNull(kindeToken);
+        assertTrue(kindeToken.valid());
+        assertEquals(connectionId, kindeToken.getConnectionId(), 
+                "getConnectionId() should return the connection_id from the token");
+    }
+
+    @Test
+    @DisplayName("getConnectionId should return connection_id from ext_provider nested structure")
+    public void testGetConnectionIdFromExtProvider() throws Exception {
+        String connectionId = "conn_enterprise_saml_789";
+        String tokenString = JwtGenerator.generateIDTokenWithExtProviderConnectionId(connectionId);
+        
+        KindeToken kindeToken = IDToken.init(tokenString, true);
+        
+        assertNotNull(kindeToken);
+        assertTrue(kindeToken.valid());
+        assertEquals(connectionId, kindeToken.getConnectionId(), 
+                "getConnectionId() should return the connection_id from ext_provider.connection_id");
+    }
+
+    @Test
+    @DisplayName("getConnectionId should return null when connection_id is not present")
+    public void testGetConnectionIdWhenNotPresent() throws Exception {
+        String tokenString = JwtGenerator.generateIDToken();
+        
+        KindeToken kindeToken = IDToken.init(tokenString, true);
+        
+        assertNotNull(kindeToken);
+        assertTrue(kindeToken.valid());
+        assertNull(kindeToken.getConnectionId(), 
+                "getConnectionId() should return null when connection_id is not in the token");
+    }
+
+    @Test
+    @DisplayName("getConnectionId should prefer direct connection_id over nested ext_provider.connection_id")
+    public void testGetConnectionIdPreferDirectOverNested() throws Exception {
+        // Create a token with direct connection_id
+        String directConnectionId = "conn_direct_123";
+        
+        // For this test, we'll use the direct one and verify it's preferred
+        String tokenString = JwtGenerator.generateIDTokenWithConnectionId(directConnectionId);
+        
+        KindeToken kindeToken = IDToken.init(tokenString, true);
+        
+        assertNotNull(kindeToken);
+        assertTrue(kindeToken.valid());
+        assertEquals(directConnectionId, kindeToken.getConnectionId(), 
+                "getConnectionId() should prefer direct connection_id claim");
+    }
+
+    @Test
+    @DisplayName("getConnectionId should work with AccessToken")
+    public void testGetConnectionIdWithAccessToken() throws Exception {
+        String connectionId = "conn_access_token_123";
+        String tokenString = JwtGenerator.generateIDTokenWithConnectionId(connectionId);
+        
+        // AccessToken uses the same BaseToken implementation
+        KindeToken kindeToken = AccessToken.init(tokenString, true);
+        
+        assertNotNull(kindeToken);
+        assertTrue(kindeToken.valid());
+        assertEquals(connectionId, kindeToken.getConnectionId(), 
+                "getConnectionId() should work with AccessToken");
+    }
+
+    @Test
+    @DisplayName("getConnectionId should return null for invalid token")
+    public void testGetConnectionIdWithInvalidToken() throws Exception {
+        String tokenString = "invalid.token.string";
+        
+        KindeToken kindeToken = IDToken.init(tokenString, false);
+        
+        assertNotNull(kindeToken);
+        assertFalse(kindeToken.valid());
+        assertNull(kindeToken.getConnectionId(), 
+                "getConnectionId() should return null for invalid tokens");
+    }
+
+    @Test
+    @DisplayName("getConnectionId should handle null ext_provider gracefully")
+    public void testGetConnectionIdWithNullExtProvider() throws Exception {
+        // Token without ext_provider should work fine
+        String tokenString = JwtGenerator.generateIDToken();
+        
+        KindeToken kindeToken = IDToken.init(tokenString, true);
+        
+        assertNotNull(kindeToken);
+        assertTrue(kindeToken.valid());
+        assertNull(kindeToken.getConnectionId(), 
+                "getConnectionId() should handle missing ext_provider gracefully");
+    }
+
+    @Test
+    @DisplayName("getConnectionId should handle ext_provider without connection_id gracefully")
+    public void testGetConnectionIdWithExtProviderButNoConnectionId() throws Exception {
+        // This test verifies that if ext_provider exists but doesn't have connection_id, it returns null
+        // We'll use a regular token and verify the behavior
+        String tokenString = JwtGenerator.generateIDToken();
+        
+        KindeToken kindeToken = IDToken.init(tokenString, true);
+        
+        assertNotNull(kindeToken);
+        assertTrue(kindeToken.valid());
+        assertNull(kindeToken.getConnectionId(), 
+                "getConnectionId() should return null when ext_provider exists but has no connection_id");
+    }
+}

--- a/kinde-core/src/test/java/com/kinde/token/ConnectionIdTokenTest.java
+++ b/kinde-core/src/test/java/com/kinde/token/ConnectionIdTokenTest.java
@@ -52,18 +52,18 @@ public class ConnectionIdTokenTest {
     @Test
     @DisplayName("getConnectionId should prefer direct connection_id over nested ext_provider.connection_id")
     public void testGetConnectionIdPreferDirectOverNested() throws Exception {
-        // Create a token with direct connection_id
+        // Create a token with both direct and nested connection_id to test preference
         String directConnectionId = "conn_direct_123";
+        String nestedConnectionId = "conn_nested_456";
         
-        // For this test, we'll use the direct one and verify it's preferred
-        String tokenString = JwtGenerator.generateIDTokenWithConnectionId(directConnectionId);
+        String tokenString = JwtGenerator.generateIDTokenWithBothConnectionIds(directConnectionId, nestedConnectionId);
         
         KindeToken kindeToken = IDToken.init(tokenString, true);
         
         assertNotNull(kindeToken);
         assertTrue(kindeToken.valid());
         assertEquals(directConnectionId, kindeToken.getConnectionId(), 
-                "getConnectionId() should prefer direct connection_id claim");
+                "getConnectionId() should prefer direct connection_id over ext_provider.connection_id");
     }
 
     @Test

--- a/kinde-core/src/test/java/com/kinde/token/ConnectionIdTokenTest.java
+++ b/kinde-core/src/test/java/com/kinde/token/ConnectionIdTokenTest.java
@@ -112,11 +112,10 @@ public class ConnectionIdTokenTest {
     @DisplayName("getConnectionId should handle ext_provider without connection_id gracefully")
     public void testGetConnectionIdWithExtProviderButNoConnectionId() throws Exception {
         // This test verifies that if ext_provider exists but doesn't have connection_id, it returns null
-        // We'll use a regular token and verify the behavior
-        String tokenString = JwtGenerator.generateIDToken();
-        
+        String tokenString = JwtGenerator.generateIDTokenWithExtProviderButNoConnectionId();
+
         KindeToken kindeToken = IDToken.init(tokenString, true);
-        
+
         assertNotNull(kindeToken);
         assertTrue(kindeToken.valid());
         assertNull(kindeToken.getConnectionId(), 

--- a/kinde-core/src/test/java/com/kinde/token/jwt/JwtGenerator.java
+++ b/kinde-core/src/test/java/com/kinde/token/jwt/JwtGenerator.java
@@ -345,4 +345,45 @@ public class JwtGenerator {
         signedJWT.sign(signer);
         return signedJWT.serialize();
     }
+
+    @SneakyThrows
+    public static String generateIDTokenWithExtProviderButNoConnectionId() {
+        RSAKey rsaJWK = new RSAKeyGenerator(2048)
+                .keyID("123")
+                .generate();
+
+        JWSSigner signer = new RSASSASigner(rsaJWK);
+        Date now = new Date();
+
+        Map<String,Object> featureFlags = new HashMap<>();
+        featureFlags.put("test_str","test_str");
+        featureFlags.put("test_integer",Integer.valueOf(1));
+        featureFlags.put("test_boolean",Boolean.valueOf(false));
+
+        // Create ext_provider with other fields but no connection_id
+        Map<String, Object> extProvider = new HashMap<>();
+        extProvider.put("provider", "google");
+        extProvider.put("provider_id", "12345");
+
+        JWTClaimsSet jwtClaims = new JWTClaimsSet.Builder()
+                .issuer("https://openid.net")
+                .subject("test")
+                .audience(Arrays.asList("https://kinde.com"))
+                .expirationTime(new Date(now.getTime() + 1000*60*10))
+                .notBeforeTime(now)
+                .issueTime(now)
+                .claim("permissions",Arrays.asList("test1","test1"))
+                .claim("org_codes",Arrays.asList("test1","test1"))
+                .claim("feature_flags",featureFlags)
+                .claim("ext_provider", extProvider)
+                .jwtID(UUID.randomUUID().toString())
+                .build();
+
+        SignedJWT signedJWT = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(rsaJWK.getKeyID()).build(),
+                jwtClaims);
+
+        signedJWT.sign(signer);
+        return signedJWT.serialize();
+    }
 }

--- a/kinde-core/src/test/java/com/kinde/token/jwt/JwtGenerator.java
+++ b/kinde-core/src/test/java/com/kinde/token/jwt/JwtGenerator.java
@@ -305,4 +305,44 @@ public class JwtGenerator {
         signedJWT.sign(signer);
         return signedJWT.serialize();
     }
+
+    @SneakyThrows
+    public static String generateIDTokenWithBothConnectionIds(String directConnectionId, String nestedConnectionId) {
+        RSAKey rsaJWK = new RSAKeyGenerator(2048)
+                .keyID("123")
+                .generate();
+
+        JWSSigner signer = new RSASSASigner(rsaJWK);
+        Date now = new Date();
+
+        Map<String,Object> featureFlags = new HashMap<>();
+        featureFlags.put("test_str","test_str");
+        featureFlags.put("test_integer",Integer.valueOf(1));
+        featureFlags.put("test_boolean",Boolean.valueOf(false));
+
+        Map<String, Object> extProvider = new HashMap<>();
+        extProvider.put("connection_id", nestedConnectionId);
+
+        JWTClaimsSet jwtClaims = new JWTClaimsSet.Builder()
+                .issuer("https://openid.net")
+                .subject("test")
+                .audience(Arrays.asList("https://kinde.com"))
+                .expirationTime(new Date(now.getTime() + 1000*60*10))
+                .notBeforeTime(now)
+                .issueTime(now)
+                .claim("permissions",Arrays.asList("test1","test1"))
+                .claim("org_codes",Arrays.asList("test1","test1"))
+                .claim("feature_flags",featureFlags)
+                .claim("connection_id", directConnectionId)
+                .claim("ext_provider", extProvider)
+                .jwtID(UUID.randomUUID().toString())
+                .build();
+
+        SignedJWT signedJWT = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(rsaJWK.getKeyID()).build(),
+                jwtClaims);
+
+        signedJWT.sign(signer);
+        return signedJWT.serialize();
+    }
 }

--- a/kinde-core/src/test/java/com/kinde/token/jwt/JwtGenerator.java
+++ b/kinde-core/src/test/java/com/kinde/token/jwt/JwtGenerator.java
@@ -230,4 +230,79 @@ public class JwtGenerator {
         signedJWT.sign(signer);
         return signedJWT.serialize();
     }
+
+    @SneakyThrows
+    public static String generateIDTokenWithConnectionId(String connectionId) {
+        RSAKey rsaJWK = new RSAKeyGenerator(2048)
+                .keyID("123")
+                .generate();
+
+        JWSSigner signer = new RSASSASigner(rsaJWK);
+        Date now = new Date();
+
+        Map<String,Object> featureFlags = new HashMap<>();
+        featureFlags.put("test_str","test_str");
+        featureFlags.put("test_integer",Integer.valueOf(1));
+        featureFlags.put("test_boolean",Boolean.valueOf(false));
+
+        JWTClaimsSet jwtClaims = new JWTClaimsSet.Builder()
+                .issuer("https://openid.net")
+                .subject("test")
+                .audience(Arrays.asList("https://kinde.com"))
+                .expirationTime(new Date(now.getTime() + 1000*60*10))
+                .notBeforeTime(now)
+                .issueTime(now)
+                .claim("permissions",Arrays.asList("test1","test1"))
+                .claim("org_codes",Arrays.asList("test1","test1"))
+                .claim("feature_flags",featureFlags)
+                .claim("connection_id", connectionId)
+                .jwtID(UUID.randomUUID().toString())
+                .build();
+
+        SignedJWT signedJWT = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(rsaJWK.getKeyID()).build(),
+                jwtClaims);
+
+        signedJWT.sign(signer);
+        return signedJWT.serialize();
+    }
+
+    @SneakyThrows
+    public static String generateIDTokenWithExtProviderConnectionId(String connectionId) {
+        RSAKey rsaJWK = new RSAKeyGenerator(2048)
+                .keyID("123")
+                .generate();
+
+        JWSSigner signer = new RSASSASigner(rsaJWK);
+        Date now = new Date();
+
+        Map<String,Object> featureFlags = new HashMap<>();
+        featureFlags.put("test_str","test_str");
+        featureFlags.put("test_integer",Integer.valueOf(1));
+        featureFlags.put("test_boolean",Boolean.valueOf(false));
+
+        Map<String, Object> extProvider = new HashMap<>();
+        extProvider.put("connection_id", connectionId);
+
+        JWTClaimsSet jwtClaims = new JWTClaimsSet.Builder()
+                .issuer("https://openid.net")
+                .subject("test")
+                .audience(Arrays.asList("https://kinde.com"))
+                .expirationTime(new Date(now.getTime() + 1000*60*10))
+                .notBeforeTime(now)
+                .issueTime(now)
+                .claim("permissions",Arrays.asList("test1","test1"))
+                .claim("org_codes",Arrays.asList("test1","test1"))
+                .claim("feature_flags",featureFlags)
+                .claim("ext_provider", extProvider)
+                .jwtID(UUID.randomUUID().toString())
+                .build();
+
+        SignedJWT signedJWT = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(rsaJWK.getKeyID()).build(),
+                jwtClaims);
+
+        signedJWT.sign(signer);
+        return signedJWT.serialize();
+    }
 }

--- a/kinde-j2ee/src/main/java/com/kinde/filter/KindeAuthenticationFilter.java
+++ b/kinde-j2ee/src/main/java/com/kinde/filter/KindeAuthenticationFilter.java
@@ -16,9 +16,12 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.kinde.constants.KindeConstants.*;
 import static com.kinde.constants.KindeJ2eeConstants.*;
+import com.kinde.session.KindeRequestParameters;
 
 public abstract class KindeAuthenticationFilter implements Filter {
     protected void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain, KindeAuthenticationAction kindeAuthenticationAction) throws IOException, ServletException {
@@ -56,15 +59,48 @@ public abstract class KindeAuthenticationFilter implements Filter {
         if (userPrincipal == null || authorizationUrl == null) {
             // Redirect to the OAuth provider's authorization page
             KindeClientSession kindeClientSession = createKindeClientSession(req);
+            
+            // Build parameters map for connection_id support
+            Map<String, String> parameters = new HashMap<>();
+            String connectionId = req.getParameter(com.kinde.constants.KindeConstants.CONNECTION_ID);
+            if (connectionId != null && !connectionId.isEmpty()) {
+                parameters.put(KindeRequestParameters.CONNECTION_ID, connectionId);
+            }
+            
             if (kindeAuthenticationAction == KindeAuthenticationAction.LOGIN) {
-                authorizationUrl = kindeClientSession.login();
+                if (parameters.isEmpty()) {
+                    authorizationUrl = kindeClientSession.login();
+                } else {
+                    Map<String, String> loginParams = new HashMap<>(parameters);
+                    loginParams.put("supports_reauth", "true");
+                    authorizationUrl = kindeClientSession.authorizationUrlWithParameters(loginParams);
+                }
             } else if (kindeAuthenticationAction == KindeAuthenticationAction.REGISTER) {
-                authorizationUrl = kindeClientSession.register();
+                if (parameters.isEmpty()) {
+                    authorizationUrl = kindeClientSession.register();
+                } else {
+                    Map<String, String> registerParams = new HashMap<>(parameters);
+                    registerParams.put("prompt", "create");
+                    authorizationUrl = kindeClientSession.authorizationUrlWithParameters(registerParams);
+                }
             } else if (kindeAuthenticationAction == KindeAuthenticationAction.CREATE_ORG) {
                 if (req.getParameter(ORG_NAME) == null) {
                     throw new ServletException("Must proved org_name query parameter to create an organisation.");
                 }
-                authorizationUrl = kindeClientSession.createOrg(req.getParameter(ORG_NAME));
+                if (parameters.isEmpty()) {
+                    authorizationUrl = kindeClientSession.createOrg(req.getParameter(ORG_NAME));
+                } else {
+                    Map<String, String> createOrgParams = new HashMap<>(parameters);
+                    createOrgParams.put("prompt", "create");
+                    createOrgParams.put("org_name", req.getParameter(ORG_NAME));
+                    authorizationUrl = kindeClientSession.authorizationUrlWithParameters(createOrgParams);
+                }
+            } else {
+                throw new ServletException("Unknown authentication action: " + kindeAuthenticationAction);
+            }
+            
+            if (authorizationUrl == null) {
+                throw new ServletException("Failed to generate authorization URL");
             }
             req.getSession().setAttribute(AUTHORIZATION_URL,authorizationUrl);
             resp.sendRedirect(authorizationUrl.getUrl().toString());
@@ -85,9 +121,7 @@ public abstract class KindeAuthenticationFilter implements Filter {
                 throw new ServletException("OAuth token exchange failed", e);
             }
         } else {
-            if (userPrincipal == null) {
-                throw new ServletException("Authentication failure as the user principal has not been set correctly");
-            }
+            // userPrincipal is not null here (otherwise we'd be in the first if block)
             HttpServletRequest wrappedRequest = new KindeHttpRequestWrapper(req, userPrincipal);
             filterChain.doFilter(wrappedRequest,servletResponse);
         }

--- a/kinde-j2ee/src/main/java/com/kinde/filter/KindeAuthenticationFilter.java
+++ b/kinde-j2ee/src/main/java/com/kinde/filter/KindeAuthenticationFilter.java
@@ -81,17 +81,19 @@ public abstract class KindeAuthenticationFilter implements Filter {
                 } else {
                     Map<String, String> registerParams = new HashMap<>(parameters);
                     registerParams.put("prompt", "create");
+                    registerParams.put("supports_reauth", "true");
                     authorizationUrl = kindeClientSession.authorizationUrlWithParameters(registerParams);
                 }
             } else if (kindeAuthenticationAction == KindeAuthenticationAction.CREATE_ORG) {
                 if (req.getParameter(ORG_NAME) == null) {
-                    throw new ServletException("Must proved org_name query parameter to create an organisation.");
+                    throw new ServletException("Must provide org_name query parameter to create an organisation.");
                 }
                 if (parameters.isEmpty()) {
                     authorizationUrl = kindeClientSession.createOrg(req.getParameter(ORG_NAME));
                 } else {
                     Map<String, String> createOrgParams = new HashMap<>(parameters);
                     createOrgParams.put("prompt", "create");
+                    createOrgParams.put("is_create_org", Boolean.TRUE.toString());
                     createOrgParams.put("org_name", req.getParameter(ORG_NAME));
                     authorizationUrl = kindeClientSession.authorizationUrlWithParameters(createOrgParams);
                 }

--- a/kinde-j2ee/src/main/java/com/kinde/servlet/KindeAuthenticationServlet.java
+++ b/kinde-j2ee/src/main/java/com/kinde/servlet/KindeAuthenticationServlet.java
@@ -17,9 +17,12 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.kinde.constants.KindeConstants.*;
 import static com.kinde.constants.KindeJ2eeConstants.*;
+import com.kinde.session.KindeRequestParameters;
 
 @Slf4j
 public class KindeAuthenticationServlet extends HttpServlet {
@@ -53,16 +56,49 @@ public class KindeAuthenticationServlet extends HttpServlet {
             }
             // Redirect to the OAuth provider's authorization page
             KindeClientSession kindeClientSession = createKindeClientSession(req);
+            
+            // Build parameters map for connection_id support
+            Map<String, String> parameters = new HashMap<>();
+            String connectionId = req.getParameter(com.kinde.constants.KindeConstants.CONNECTION_ID);
+            if (connectionId != null && !connectionId.isEmpty()) {
+                parameters.put(KindeRequestParameters.CONNECTION_ID, connectionId);
+            }
+            
             AuthorizationUrl authorizationUrl = null;
             if (kindeAuthenticationAction == KindeAuthenticationAction.LOGIN) {
-                authorizationUrl = kindeClientSession.login();
+                if (parameters.isEmpty()) {
+                    authorizationUrl = kindeClientSession.login();
+                } else {
+                    Map<String, String> loginParams = new HashMap<>(parameters);
+                    loginParams.put("supports_reauth", "true");
+                    authorizationUrl = kindeClientSession.authorizationUrlWithParameters(loginParams);
+                }
             } else if (kindeAuthenticationAction == KindeAuthenticationAction.REGISTER) {
-                authorizationUrl = kindeClientSession.register();
+                if (parameters.isEmpty()) {
+                    authorizationUrl = kindeClientSession.register();
+                } else {
+                    Map<String, String> registerParams = new HashMap<>(parameters);
+                    registerParams.put("prompt", "create");
+                    authorizationUrl = kindeClientSession.authorizationUrlWithParameters(registerParams);
+                }
             } else if (kindeAuthenticationAction == KindeAuthenticationAction.CREATE_ORG) {
                 if (req.getParameter(ORG_NAME) == null) {
                     throw new ServletException("Must provide org_name query parameter to create an organisation.");
                 }
-                authorizationUrl = kindeClientSession.createOrg(req.getParameter(ORG_NAME));
+                if (parameters.isEmpty()) {
+                    authorizationUrl = kindeClientSession.createOrg(req.getParameter(ORG_NAME));
+                } else {
+                    Map<String, String> createOrgParams = new HashMap<>(parameters);
+                    createOrgParams.put("prompt", "create");
+                    createOrgParams.put("org_name", req.getParameter(ORG_NAME));
+                    authorizationUrl = kindeClientSession.authorizationUrlWithParameters(createOrgParams);
+                }
+            } else {
+                throw new ServletException("Unknown authentication action: " + kindeAuthenticationAction);
+            }
+            
+            if (authorizationUrl == null) {
+                throw new ServletException("Failed to generate authorization URL");
             }
             req.getSession().setAttribute(AUTHORIZATION_URL,authorizationUrl);
             req.getSession().setAttribute(POST_LOGIN_URL,postLoginUrl);

--- a/kinde-j2ee/src/main/java/com/kinde/servlet/KindeAuthenticationServlet.java
+++ b/kinde-j2ee/src/main/java/com/kinde/servlet/KindeAuthenticationServlet.java
@@ -79,6 +79,7 @@ public class KindeAuthenticationServlet extends HttpServlet {
                 } else {
                     Map<String, String> registerParams = new HashMap<>(parameters);
                     registerParams.put("prompt", "create");
+                    registerParams.put("supports_reauth", "true");
                     authorizationUrl = kindeClientSession.authorizationUrlWithParameters(registerParams);
                 }
             } else if (kindeAuthenticationAction == KindeAuthenticationAction.CREATE_ORG) {
@@ -90,6 +91,7 @@ public class KindeAuthenticationServlet extends HttpServlet {
                 } else {
                     Map<String, String> createOrgParams = new HashMap<>(parameters);
                     createOrgParams.put("prompt", "create");
+                    createOrgParams.put("is_create_org", Boolean.TRUE.toString());
                     createOrgParams.put("org_name", req.getParameter(ORG_NAME));
                     authorizationUrl = kindeClientSession.authorizationUrlWithParameters(createOrgParams);
                 }

--- a/kinde-j2ee/src/test/java/com/kinde/filter/ConnectionIdFilterTest.java
+++ b/kinde-j2ee/src/test/java/com/kinde/filter/ConnectionIdFilterTest.java
@@ -12,19 +12,25 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
+import java.net.URL;
 import java.security.Principal;
+import java.util.Map;
 
-import static com.kinde.constants.KindeConstants.CONNECTION_ID;
+import static com.kinde.constants.KindeConstants.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
 public class ConnectionIdFilterTest {
@@ -57,17 +63,29 @@ public class ConnectionIdFilterTest {
     private AuthorizationUrl authorizationUrl;
 
     private KindeLoginFilter filter;
+    private MockedStatic<KindeSingleton> kindeSingletonStatic;
 
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
         filter = new KindeLoginFilter();
         
+        // Static mocking for KindeSingleton
+        kindeSingletonStatic = Mockito.mockStatic(KindeSingleton.class);
+        kindeSingletonStatic.when(KindeSingleton::getInstance).thenReturn(kindeSingleton);
+        
         when(request.getSession()).thenReturn(session);
         when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/test"));
         when(session.getAttribute(anyString())).thenReturn(null);
         when(request.getParameter("code")).thenReturn(null);
         when(request.getParameter("error")).thenReturn(null);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (kindeSingletonStatic != null) {
+            kindeSingletonStatic.close();
+        }
     }
 
     @Test
@@ -79,8 +97,7 @@ public class ConnectionIdFilterTest {
         when(request.getParameter("org_code")).thenReturn(null);
         when(request.getParameter("lang")).thenReturn(null);
         
-        // Mock KindeSingleton
-        KindeSingleton.setInstance(kindeSingleton);
+        // Mock KindeSingleton chain
         when(kindeSingleton.getKindeClientBuilder()).thenReturn(kindeClientBuilder);
         when(kindeClientBuilder.redirectUri(anyString())).thenReturn(kindeClientBuilder);
         when(kindeClientBuilder.grantType(any(AuthorizationType.class))).thenReturn(kindeClientBuilder);
@@ -90,13 +107,13 @@ public class ConnectionIdFilterTest {
         when(kindeClientBuilder.build()).thenReturn(kindeClient);
         when(kindeClient.clientSession()).thenReturn(kindeClientSession);
         when(kindeClientSession.authorizationUrlWithParameters(any())).thenReturn(authorizationUrl);
-        when(authorizationUrl.getUrl()).thenReturn(new java.net.URL("http://example.com/auth?connection_id=" + connectionId));
+        when(authorizationUrl.getUrl()).thenReturn(new URL("http://example.com/auth?connection_id=" + connectionId));
         
         // Execute
         filter.doFilter(request, response, filterChain);
         
         // Verify
-        verify(kindeClientSession).authorizationUrlWithParameters(argThat(params -> 
+        verify(kindeClientSession).authorizationUrlWithParameters(argThat((Map<String, String> params) -> 
             params.containsKey(CONNECTION_ID) && 
             params.get(CONNECTION_ID).equals(connectionId) &&
             params.containsKey("supports_reauth")
@@ -112,8 +129,7 @@ public class ConnectionIdFilterTest {
         when(request.getParameter("org_code")).thenReturn(null);
         when(request.getParameter("lang")).thenReturn(null);
         
-        // Mock KindeSingleton
-        KindeSingleton.setInstance(kindeSingleton);
+        // Mock KindeSingleton chain
         when(kindeSingleton.getKindeClientBuilder()).thenReturn(kindeClientBuilder);
         when(kindeClientBuilder.redirectUri(anyString())).thenReturn(kindeClientBuilder);
         when(kindeClientBuilder.grantType(any(AuthorizationType.class))).thenReturn(kindeClientBuilder);
@@ -123,7 +139,7 @@ public class ConnectionIdFilterTest {
         when(kindeClientBuilder.build()).thenReturn(kindeClient);
         when(kindeClient.clientSession()).thenReturn(kindeClientSession);
         when(kindeClientSession.login()).thenReturn(authorizationUrl);
-        when(authorizationUrl.getUrl()).thenReturn(new java.net.URL("http://example.com/auth"));
+        when(authorizationUrl.getUrl()).thenReturn(new URL("http://example.com/auth"));
         
         // Execute
         filter.doFilter(request, response, filterChain);

--- a/kinde-j2ee/src/test/java/com/kinde/filter/ConnectionIdFilterTest.java
+++ b/kinde-j2ee/src/test/java/com/kinde/filter/ConnectionIdFilterTest.java
@@ -1,0 +1,135 @@
+package com.kinde.filter;
+
+import com.kinde.KindeClient;
+import com.kinde.KindeClientBuilder;
+import com.kinde.KindeClientSession;
+import com.kinde.authorization.AuthorizationType;
+import com.kinde.authorization.AuthorizationUrl;
+import com.kinde.constants.KindeAuthenticationAction;
+import com.kinde.servlet.KindeSingleton;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.security.Principal;
+
+import static com.kinde.constants.KindeConstants.CONNECTION_ID;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class ConnectionIdFilterTest {
+
+    @Mock
+    private HttpServletRequest request;
+    
+    @Mock
+    private HttpServletResponse response;
+    
+    @Mock
+    private FilterChain filterChain;
+    
+    @Mock
+    private HttpSession session;
+    
+    @Mock
+    private KindeSingleton kindeSingleton;
+    
+    @Mock
+    private KindeClientBuilder kindeClientBuilder;
+    
+    @Mock
+    private KindeClient kindeClient;
+    
+    @Mock
+    private KindeClientSession kindeClientSession;
+    
+    @Mock
+    private AuthorizationUrl authorizationUrl;
+
+    private KindeLoginFilter filter;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        filter = new KindeLoginFilter();
+        
+        when(request.getSession()).thenReturn(session);
+        when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/test"));
+        when(session.getAttribute(anyString())).thenReturn(null);
+        when(request.getParameter("code")).thenReturn(null);
+        when(request.getParameter("error")).thenReturn(null);
+    }
+
+    @Test
+    @DisplayName("Filter should include connection_id in authorization URL when provided as request parameter")
+    public void testFilterWithConnectionId() throws ServletException, IOException {
+        // Setup
+        String connectionId = "conn_123456789";
+        when(request.getParameter(CONNECTION_ID)).thenReturn(connectionId);
+        when(request.getParameter("org_code")).thenReturn(null);
+        when(request.getParameter("lang")).thenReturn(null);
+        
+        // Mock KindeSingleton
+        KindeSingleton.setInstance(kindeSingleton);
+        when(kindeSingleton.getKindeClientBuilder()).thenReturn(kindeClientBuilder);
+        when(kindeClientBuilder.redirectUri(anyString())).thenReturn(kindeClientBuilder);
+        when(kindeClientBuilder.grantType(any(AuthorizationType.class))).thenReturn(kindeClientBuilder);
+        when(kindeClientBuilder.orgCode(any())).thenReturn(kindeClientBuilder);
+        when(kindeClientBuilder.lang(any())).thenReturn(kindeClientBuilder);
+        when(kindeClientBuilder.scopes(anyString())).thenReturn(kindeClientBuilder);
+        when(kindeClientBuilder.build()).thenReturn(kindeClient);
+        when(kindeClient.clientSession()).thenReturn(kindeClientSession);
+        when(kindeClientSession.authorizationUrlWithParameters(any())).thenReturn(authorizationUrl);
+        when(authorizationUrl.getUrl()).thenReturn(new java.net.URL("http://example.com/auth?connection_id=" + connectionId));
+        
+        // Execute
+        filter.doFilter(request, response, filterChain);
+        
+        // Verify
+        verify(kindeClientSession).authorizationUrlWithParameters(argThat(params -> 
+            params.containsKey(CONNECTION_ID) && 
+            params.get(CONNECTION_ID).equals(connectionId) &&
+            params.containsKey("supports_reauth")
+        ));
+        verify(response).sendRedirect(anyString());
+    }
+
+    @Test
+    @DisplayName("Filter should work without connection_id when not provided")
+    public void testFilterWithoutConnectionId() throws ServletException, IOException {
+        // Setup
+        when(request.getParameter(CONNECTION_ID)).thenReturn(null);
+        when(request.getParameter("org_code")).thenReturn(null);
+        when(request.getParameter("lang")).thenReturn(null);
+        
+        // Mock KindeSingleton
+        KindeSingleton.setInstance(kindeSingleton);
+        when(kindeSingleton.getKindeClientBuilder()).thenReturn(kindeClientBuilder);
+        when(kindeClientBuilder.redirectUri(anyString())).thenReturn(kindeClientBuilder);
+        when(kindeClientBuilder.grantType(any(AuthorizationType.class))).thenReturn(kindeClientBuilder);
+        when(kindeClientBuilder.orgCode(any())).thenReturn(kindeClientBuilder);
+        when(kindeClientBuilder.lang(any())).thenReturn(kindeClientBuilder);
+        when(kindeClientBuilder.scopes(anyString())).thenReturn(kindeClientBuilder);
+        when(kindeClientBuilder.build()).thenReturn(kindeClient);
+        when(kindeClient.clientSession()).thenReturn(kindeClientSession);
+        when(kindeClientSession.login()).thenReturn(authorizationUrl);
+        when(authorizationUrl.getUrl()).thenReturn(new java.net.URL("http://example.com/auth"));
+        
+        // Execute
+        filter.doFilter(request, response, filterChain);
+        
+        // Verify - should use login() method when no connection_id
+        verify(kindeClientSession).login();
+        verify(response).sendRedirect(anyString());
+    }
+}


### PR DESCRIPTION
- Add CONNECTION_ID constant to KindeRequestParameters and KindeConstants
- Implement getConnectionId() method in KindeToken interface and BaseToken
  - Supports direct connection_id claim
  - Supports nested ext_provider.connection_id structure
- Add connection_id parameter support to authorizationUrlWithParameters()
- Update J2EE filter and servlet to read connection_id from request parameters
  - Works with LOGIN, REGISTER, and CREATE_ORG actions
- Add comprehensive test coverage:
  - ConnectionIdTest: 5 tests for authorization URL generation
  - ConnectionIdTokenTest: 8 tests for token extraction
  - ConnectionIdFilterTest: J2EE filter integration tests
- Add JWT generator helpers for testing connection_id claims

This implementation enables:
- Passing connection_id when generating authorization URLs for social/enterprise login
- Extracting connection_id from tokens (both direct and nested structures)
- Automatic connection_id support in J2EE via request parameters
- Core support available for SpringBoot (requires Spring Security config)

All changes are backward compatible and optional.

# Explain your changes

_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication flows (login, registration, org creation) accept an optional connection_id and include related URL parameters (supports_reauth, prompt, org name) while preserving existing behavior when absent.
  * Tokens expose a connection_id accessor that reads direct or nested provider claims and returns null when not present.

* **Tests**
  * Added comprehensive tests validating connection_id propagation in authorization URLs and extraction from various token formats and edge cases.

* **Bug Fixes**
  * Improved validation and error messaging for unknown actions and missing authorization URLs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->