### PR TITLE
fix(deps): update dependency ch.qos.logback:logback-classic to v1.5.32

### DIFF
--- a/playground/kinde-springboot-starter-example/pom.xml
+++ b/playground/kinde-springboot-starter-example/pom.xml
@@ -73,7 +73,7 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>runtime</scope>
-      <version>1.5.19</version>
+      <version>1.5.32</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
logback-classic version bump 1.5.19 -> 1.5.32

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime dependencies for improved stability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->