### PR TITLE
fix(security): patch Thymeleaf SSTI, Actuator auth bypass, and logback CVE-2026-1225

### DIFF
--- a/playground/kinde-springboot-pkce-client-example/pom.xml
+++ b/playground/kinde-springboot-pkce-client-example/pom.xml
@@ -28,16 +28,6 @@
             <version>3.5.5</version>
         </dependency>
         <dependency>
-            <groupId>org.thymeleaf</groupId>
-            <artifactId>thymeleaf</artifactId>
-            <version>3.1.4.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>org.thymeleaf</groupId>
-            <artifactId>thymeleaf-spring6</artifactId>
-            <version>3.1.4.RELEASE</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
             <version>3.5.5</version>

--- a/playground/kinde-springboot-pkce-client-example/pom.xml
+++ b/playground/kinde-springboot-pkce-client-example/pom.xml
@@ -28,6 +28,16 @@
             <version>3.5.5</version>
         </dependency>
         <dependency>
+            <groupId>org.thymeleaf</groupId>
+            <artifactId>thymeleaf</artifactId>
+            <version>3.1.4.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.thymeleaf</groupId>
+            <artifactId>thymeleaf-spring6</artifactId>
+            <version>3.1.4.RELEASE</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
             <version>3.5.5</version>

--- a/playground/kinde-springboot-starter-example/pom.xml
+++ b/playground/kinde-springboot-starter-example/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
-      <version>3.5.6</version>
+      <version>3.5.12</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -47,12 +47,12 @@
     <dependency>
       <groupId>org.thymeleaf</groupId>
       <artifactId>thymeleaf</artifactId>
-      <version>3.1.3.RELEASE</version>
+      <version>3.1.4.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.thymeleaf</groupId>
       <artifactId>thymeleaf-spring6</artifactId>
-      <version>3.1.3.RELEASE</version>
+      <version>3.1.4.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -73,7 +73,7 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>runtime</scope>
-      <version>1.5.19</version>
+      <version>1.5.32</version>
     </dependency>
 
     <dependency>

--- a/playground/kinde-springboot-thymeleaf-full-example/pom.xml
+++ b/playground/kinde-springboot-thymeleaf-full-example/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>3.5.5</version>
+            <version>3.5.12</version>
         </dependency>
 
         <dependency>
@@ -60,6 +60,16 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
             <version>3.5.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.thymeleaf</groupId>
+            <artifactId>thymeleaf</artifactId>
+            <version>3.1.4.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.thymeleaf</groupId>
+            <artifactId>thymeleaf-spring6</artifactId>
+            <version>3.1.4.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary

Supersedes #228 (which has branch conflicts and a Snyk failure because it only upgrades logback to 1.5.20 instead of the latest patched version 1.5.32).

This PR fixes all CVE vulnerabilities identified across the playground modules.

## Changes

| Dependency | From | To | CVE / Reason |
|---|---|---|---|
| `org.thymeleaf:thymeleaf` | 3.1.3.RELEASE | 3.1.4.RELEASE | SSTI (CRITICAL) |
| `org.thymeleaf:thymeleaf-spring6` | 3.1.3.RELEASE | 3.1.4.RELEASE | SSTI (CRITICAL) |
| `spring-boot-starter-actuator` | 3.5.5 / 3.5.6 | 3.5.12 | Auth bypass (HIGH) |
| `ch.qos.logback:logback-classic` | 1.5.19 | 1.5.32 | CVE-2026-1225 ACE (HIGH) |

## Modules affected

- `playground/kinde-springboot-starter-example`
- `playground/kinde-springboot-thymeleaf-full-example`
- `playground/kinde-springboot-pkce-client-example` - thymeleaf explicit override added (was getting 3.1.3 transitively via Spring Boot 3.5.x BOM)

## Notes

- **No breaking changes.** Only dependency version bumps in playground modules.
- Build verified: `mvn clean test-compile` passes on all affected modules.

Closes #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies across multiple example Spring Boot projects to improve stability and compatibility.
  * Added explicit Thymeleaf template engine dependencies to projects requiring template rendering support.
  * Patched security and maintenance updates for logging and actuator components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->