### PR TITLE
fix(springboot): pin JUnit Platform to match JUnit Jupiter version

### DIFF
--- a/kinde-springboot/kinde-springboot-core/pom.xml
+++ b/kinde-springboot/kinde-springboot-core/pom.xml
@@ -77,6 +77,27 @@
         <artifactId>junit-jupiter-params</artifactId>
         <version>${junit-jupiter.version}</version>
       </dependency>
+      <!--
+        Pin the JUnit Platform artifacts to the same version as JUnit Jupiter. In the JUnit 6
+        line Jupiter and Platform share the same version, and the engine requires the matching
+        Platform; otherwise the inherited Platform from Spring Boot's BOM splits from Jupiter
+        and fails at runtime with IllegalAccessError.
+      -->
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-commons</artifactId>
+        <version>${junit-jupiter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-engine</artifactId>
+        <version>${junit-jupiter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-launcher</artifactId>
+        <version>${junit-jupiter.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/kinde-springboot/kinde-springboot-starter/pom.xml
+++ b/kinde-springboot/kinde-springboot-starter/pom.xml
@@ -50,6 +50,22 @@
         <artifactId>junit-jupiter-params</artifactId>
         <version>${junit-jupiter.version}</version>
       </dependency>
+      <!-- Keep JUnit Platform aligned with JUnit Jupiter (shared version in the JUnit 6 line). -->
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-commons</artifactId>
+        <version>${junit-jupiter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-engine</artifactId>
+        <version>${junit-jupiter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-launcher</artifactId>
+        <version>${junit-jupiter.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/playground/kinde-springboot-pkce-client-example/pom.xml
+++ b/playground/kinde-springboot-pkce-client-example/pom.xml
@@ -48,6 +48,22 @@
                 <artifactId>junit-jupiter-params</artifactId>
                 <version>${junit-jupiter.version}</version>
             </dependency>
+            <!-- Keep JUnit Platform aligned with JUnit Jupiter (shared version in the JUnit 6 line). -->
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-commons</artifactId>
+                <version>${junit-jupiter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-engine</artifactId>
+                <version>${junit-jupiter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>${junit-jupiter.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/playground/kinde-springboot-starter-example/pom.xml
+++ b/playground/kinde-springboot-starter-example/pom.xml
@@ -51,6 +51,22 @@
         <artifactId>junit-jupiter-params</artifactId>
         <version>${junit-jupiter.version}</version>
       </dependency>
+      <!-- Keep JUnit Platform aligned with JUnit Jupiter (shared version in the JUnit 6 line). -->
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-commons</artifactId>
+        <version>${junit-jupiter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-engine</artifactId>
+        <version>${junit-jupiter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-launcher</artifactId>
+        <version>${junit-jupiter.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/playground/kinde-springboot-thymeleaf-full-example/pom.xml
+++ b/playground/kinde-springboot-thymeleaf-full-example/pom.xml
@@ -57,6 +57,22 @@
                 <artifactId>junit-jupiter-params</artifactId>
                 <version>${junit-jupiter.version}</version>
             </dependency>
+            <!-- Keep JUnit Platform aligned with JUnit Jupiter (shared version in the JUnit 6 line). -->
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-commons</artifactId>
+                <version>${junit-jupiter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-engine</artifactId>
+                <version>${junit-jupiter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>${junit-jupiter.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Pin JUnit Platform to match JUnit Jupiter version

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Consolidated JUnit Platform test dependency management across core modules and example applications to keep test execution consistent.
  * Explicitly pinned JUnit Platform component versions (commons, engine, launcher) to align with the existing JUnit Jupiter version, reducing the risk of version mismatch issues during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->